### PR TITLE
chore: Don't run CI twice when opening pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ name: ci
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:


### PR DESCRIPTION
Only run it for pull requests, or for pushes to master